### PR TITLE
Make the controller a class as per Play 2.4 routing

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -14,6 +14,9 @@ class Application extends Controller {
     val b = request.body.validate[Book]
     b.fold(
       errors => {
+        // There's a warning here, but it's not clear if toFlatJson
+        // should really have been deprecated
+        // https://github.com/playframework/playframework/issues/5531
         BadRequest(Json.obj("status" -> "OK", "message" -> JsError.toFlatJson(errors)))
       },
       book => {

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -4,7 +4,7 @@ import play.api.libs.json._
 import play.api.mvc._
 import models.Book._
 
-object Application extends Controller {
+class Application extends Controller {
 
   def listBooks = Action {
     Ok(Json.toJson(books))


### PR DESCRIPTION
When I check out this project and try to run, I get compilation errors like "type Application is not a member of package controllers".

I think this has been caused by [the update from Play 2.3 to 2.5 ](https://github.com/amitdev/simple-rest-scala/commit/2a2ea03697b8a2c6463236a5180835dc112ecf6d), with a change in how routing code is generated since Play 2.4, see http://stackoverflow.com/a/30544381/14955

Changing `object Application` to `class Application` seems to be the preferred and least intrustive fix.
